### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/paypal-sdk/core/api/data_types/simple_types.rb
+++ b/lib/paypal-sdk/core/api/data_types/simple_types.rb
@@ -29,7 +29,7 @@ module PayPal::SDK::Core
 
         class Boolean
           def self.new(boolean)
-            ( boolean == 0 || boolean == "" || boolean =~ /^(false|f|no|n|0)$/i ) ? false : !!boolean
+            boolean == 0 || boolean == "" || /^(false|f|no|n|0)$/i.match?(boolean) ? false : !!boolean
           end
         end
 


### PR DESCRIPTION
Fixing deprecation warning thrown by `simple_types.rb:32`:

`/builds/global-app-testing/apps/gat-app/vendor/bundle/ruby/2.7.0/gems/paypal-sdk-core-0.3.4/lib/paypal-sdk/core/api/data_types/simple_types.rb:32: warning: deprecated Object#=~ is called on FalseClass; it always returns nil`